### PR TITLE
Some fixes to dump-ical

### DIFF
--- a/mutt/dump-ical.py
+++ b/mutt/dump-ical.py
@@ -3,6 +3,7 @@
 import sys
 import warnings
 import vobject
+import datetime
 
 
 def get_invitation_from_path(path):
@@ -21,34 +22,44 @@ def person_string(c):
 
 
 def when_str_of_start_end(s, e):
-    date_format = "%a, %d %b %Y at %H:%M"
-    until_format = "%H:%M" if s.date() == e.date() else date_format
-    return "{} -- {}".format(s.strftime(date_format), e.strftime(until_format))
+    datetime_format = "%a, %d %b %Y at %H:%M"
+
+    # sometimes, s and e can be dates only, so convert them to datetimes
+    if type(s) == datetime.date:
+        s = datetime.datetime.combine(s, datetime.time.min)
+    if type(e) == datetime.date:
+        e = datetime.datetime.combine(e, datetime.time.min)
+
+    until_format = "%H:%M" if s.date() == e.date() else datetime_format
+    return "{} -- {}".format(s.strftime(datetime_format), e.strftime(until_format))
 
 
 def pretty_print_invitation(invitation):
     event = invitation.vevent.contents
     title = event['summary'][0].value
-    org = event['organizer'][0]
-    invitees = event['attendee']
+    org = event['organizer'][0] if 'organizer' in event else None
+    invitees = event['attendee'] if 'attendee' in event else None
     start = event['dtstart'][0].value
     end = event['dtend'][0].value
-    location = event['location'][0].value
+    location = event['location'][0].value if 'location' in event else None
     description = event['description'][0].value
-    sequence = event['sequence'][0].value
+    sequence = event['sequence'][0].value if 'sequence' in event else None
     print("="*70)
-    if int(sequence) > 0:
+    if sequence is not None and int(sequence) > 0:
         print("MEETING UPDATE".center(70))
     else:
         print("MEETING INVITATION".center(70))
     print("="*70)
     print("Event:\n\t{}".format(title))
-    print("Organiser:\n\t{}".format(person_string(org)))
-    print("Invitees:")
-    for i in invitees:
-        print("\t{}".format(person_string(i)))
+    if org:
+        print("Organiser:\n\t{}".format(person_string(org)))
+    if invitees:
+        print("Invitees:")
+        for i in invitees:
+            print("\t{}".format(person_string(i)))
     print("When:\n\t{}".format(when_str_of_start_end(start, end)))
-    print("Location:\n\t{}".format(location))
+    if location:
+        print("Location:\n\t{}".format(location))
     print("---\n{}---".format(description))
 
 

--- a/mutt/dump-ical.py
+++ b/mutt/dump-ical.py
@@ -17,13 +17,13 @@ def get_invitation_from_path(path):
 
 
 def person_string(c):
-    return "%s %s" % (c.params['CN'][0], "<%s>" % c.value.split(':')[1])
+    return "{} {}".format(c.params['CN'][0], "<%s>" % c.value.split(':')[1])
 
 
 def when_str_of_start_end(s, e):
     date_format = "%a, %d %b %Y at %H:%M"
     until_format = "%H:%M" if s.date() == e.date() else date_format
-    return "%s -- %s" % (s.strftime(date_format), e.strftime(until_format))
+    return "{} -- {}".format(s.strftime(date_format), e.strftime(until_format))
 
 
 def pretty_print_invitation(invitation):
@@ -36,25 +36,25 @@ def pretty_print_invitation(invitation):
     location = event['location'][0].value
     description = event['description'][0].value
     sequence = event['sequence'][0].value
-    print "="*70
+    print("="*70)
     if int(sequence) > 0:
-        print "MEETING UPDATE".center(70)
+        print("MEETING UPDATE".center(70))
     else:
-        print "MEETING INVITATION".center(70)
-    print "="*70
-    print "Event:\n\t%s" % title.encode('utf-8')
-    print "Organiser:\n\t%s" % person_string(org).encode('utf-8')
-    print "Invitees:"
+        print("MEETING INVITATION".center(70))
+    print("="*70)
+    print("Event:\n\t{}".format(title))
+    print("Organiser:\n\t{}".format(person_string(org)))
+    print("Invitees:")
     for i in invitees:
-        print "\t%s" % person_string(i).encode('utf-8')
-    print "When:\n\t%s" % when_str_of_start_end(start, end).encode('utf-8')
-    print "Location:\n\t%s" % location.encode('utf-8')
-    print "---\n%s---" % description.encode('utf-8')
+        print("\t{}".format(person_string(i)))
+    print("When:\n\t{}".format(when_str_of_start_end(start, end)))
+    print("Location:\n\t{}".format(location))
+    print("---\n{}---".format(description))
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2 or sys.argv[1].startswith('-'):
-        sys.stderr.write("Usage: %s <filename.ics>\n" % sys.argv[0])
+        sys.stderr.write("Usage: %s <filename.ics>\n".format(sys.argv[0]))
         sys.exit(2)
     inv = get_invitation_from_path(sys.argv[1])
     pretty_print_invitation(inv)


### PR DESCRIPTION
let dump-ical use string format method  
sometimes, ics files from other applications don't contain all fields that were expected here. start and end date may also be passed as date

Bonus: Python 3 support :+1: 
